### PR TITLE
make ruby-yarn more HA; can connect to multiple servers

### DIFF
--- a/lib/ruby-yarn/version.rb
+++ b/lib/ruby-yarn/version.rb
@@ -15,5 +15,5 @@
 #
 
 module RubyYarn
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/ruby-yarn.gemspec
+++ b/ruby-yarn.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.required_ruby_version = '>= 1.9.2'
 end


### PR DESCRIPTION
Couple random things about this:
lazily connects. since everything routes through the various GET commands, I put the `connect!` method in the `def get` method; might not be a bad idea to put it in initialize though
`connected?` is stateful in that - it connects once, but does not listen to see if the connection has been dropped. 
Per [Yarn docs](https://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/ResourceManagerHA.html#Client_ApplicationMaster_and_NodeManager_on_RM_failover), expects to be initialized with a list of all resource managers, separated by commas. 
